### PR TITLE
Added autoloader for jackalope lib.

### DIFF
--- a/www/autoloader.php
+++ b/www/autoloader.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Simple local autoloader for jackalope libs, since the one in Jackalope depends on Symfony's UniversalClassLoader
+ * component, and PHPCRBrowser isn't.
+ *
+ * @author Gerard van Helden <drm@melp.nl>
+ */
+
+$autoloadMappings = array(
+    'Jackalope'     => __DIR__ . '/../ext/jackalope/src/',
+    'PHPCR\Util'    => __DIR__ . '/../ext/jackalope/lib/phpcr-utils/src',
+    'PHPCR'         => __DIR__ . '/../ext/jackalope/lib/phpcr/src/'
+);
+
+spl_autoload_register(function($cn) use ($autoloadMappings) {
+    $strippedCn = trim($cn, '\\');
+    foreach($autoloadMappings as $prefix => $path) {
+        if (substr($strippedCn, 0, strlen($prefix)) == $prefix ) {
+            $fn = $path . str_replace('\\', '//', $strippedCn) . '.php';
+            if(is_file($fn)) {
+                require_once $fn;
+                return true;
+            }
+        }
+    }
+    return false;
+});

--- a/www/index.php
+++ b/www/index.php
@@ -4,7 +4,8 @@
  *
  * @return jr_cr_session
  */
-include('../ext/jackalope/src/Jackalope/autoloader.php');
+
+require_once 'autoloader.php';
 
 function getJRSession() {
     $jcrConfig = api_config::getInstance()->jcr['default'];


### PR DESCRIPTION
The one provided in the jackalope library depends on the Symfony autoloader component currently, which isn't included in the phpcrbrowser. The referred autoloader.php doesn't exist in the latest Jackalope, so I added a  local autoloader callback to get it running again.

Not sure if you would rather have it in inc/ or localinc/ but at least the code works :)
